### PR TITLE
Change the request frequency on TdBasicSimulation.scala

### DIFF
--- a/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
+++ b/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
@@ -28,15 +28,17 @@ class TdBasicSimulation extends Simulation {
 
   setUp(
     scn.inject(
-      constantUsersPerSec(5.0) // ① 5 requests/sec
-        .during(1.hour)        // ② 1 hour total
+//      constantUsersPerSec(5.0) // ① 5 requests/sec
+//        .during(1.hour)        // ② 1 hour total
+      constantUsersPerSec(simulationConfig.maxConcurrentClients.doubleValue())
+        .during(simulationConfig.testDurationSeconds)
     )
   ).throttle(
     reachRps(5).in(10.seconds), // Gradually reach 5 RPS
     holdFor(1.hour)             // Sustain for 1 hour
   ).maxDuration(1.hour)
-   .assertions(
-     global.allRequests.count.lte(5000), // ② max 5000 requests
-     forAll.requestsPerSec.lte(10)       // ③ concurrency <= 10
-   )
+    .assertions(
+      global.allRequests.count.lte(5000), // ② max 5000 requests
+      forAll.requestsPerSec.lte(10)       // ③ concurrency <= 10
+    )
 }

--- a/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
+++ b/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
@@ -28,8 +28,15 @@ class TdBasicSimulation extends Simulation {
 
   setUp(
     scn.inject(
-      constantUsersPerSec(simulationConfig.maxConcurrentClients.doubleValue())
-        .during(simulationConfig.testDurationSeconds)
+      constantUsersPerSec(5.0) // ① 5 requests/sec
+        .during(1.hour)        // ② 1 hour total
     )
-  )
+  ).throttle(
+    reachRps(5).in(10.seconds), // Gradually reach 5 RPS
+    holdFor(1.hour)             // Sustain for 1 hour
+  ).maxDuration(1.hour)
+   .assertions(
+     global.requests.count.lte(5000),       // ② max 5000 requests
+     global.activeUsers.count.lte(10)       // ③ concurrency <= 10
+   )
 }

--- a/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
+++ b/src/test/scala/io/github/yuokada/simulations/TdBasicSimulation.scala
@@ -36,7 +36,7 @@ class TdBasicSimulation extends Simulation {
     holdFor(1.hour)             // Sustain for 1 hour
   ).maxDuration(1.hour)
    .assertions(
-     global.requests.count.lte(5000),       // ② max 5000 requests
-     global.activeUsers.count.lte(10)       // ③ concurrency <= 10
+     global.allRequests.count.lte(5000), // ② max 5000 requests
+     forAll.requestsPerSec.lte(10)       // ③ concurrency <= 10
    )
 }


### PR DESCRIPTION
## Overview

Request to ChatGPT.
```
Could you rewrite the following code with the same conditions?
###
setUp(
    scn.inject(
      constantUsersPerSec(simulationConfig.maxConcurrentClients.doubleValue())
        .during(simulationConfig.testDurationSeconds)
    )
  )
```

Here is the last request to ChatGPT.

```
I have a question about how to submit requests via Gatling. 
Please output the code that sends a request that meets the following conditions.
###
1. Requests per seconds is 5
2. 5000 requests are submitted in a hour in total. 
3. The max concurrency is 10

The lower the ordinal number, the higher the priority.
```