### PR TITLE
Replace with spotless-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,7 @@
                         <configuration>
                             <scala>
                                 <scalafmt>
-                                    <!-- <version>3.9.10</version> -->
-                                    <!-- <version>3.8.3</version> -->
+                                    <version>3.7.3</version>
                                     <file>${project.basedir}/.scalafmt.conf</file>
                                     <scalaMajorVersion>${scala.major-version}</scalaMajorVersion>
                                 </scalafmt>

--- a/pom.xml
+++ b/pom.xml
@@ -153,17 +153,24 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.antipathy</groupId>
-                        <artifactId>mvn-scalafmt_${scala.major-version}</artifactId>
-                        <version>1.1.1684076452.9f83818</version>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <version>2.42.0</version>
                         <configuration>
-                            <configLocation>${project.basedir}/.scalafmt.conf</configLocation>
+                            <scala>
+                                <scalafmt>
+                                    <!-- <version>3.9.10</version> -->
+                                    <!-- <version>3.8.3</version> -->
+                                    <file>${project.basedir}/.scalafmt.conf</file>
+                                    <scalaMajorVersion>${scala.major-version}</scalaMajorVersion>
+                                </scalafmt>
+                            </scala>
                         </configuration>
                         <executions>
                             <execution>
                                 <phase>validate</phase>
                                 <goals>
-                                    <goal>format</goal>
+                                    <goal>apply</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
This pull request updates the project's code formatting tool configuration in the `pom.xml`. The change replaces the previous Scala formatting plugin with a more modern and widely used alternative, ensuring better maintainability and compatibility.

Build tooling and formatting:

* Replaced the `mvn-scalafmt` plugin with the `spotless-maven-plugin` for Scala code formatting, updating the configuration to use the `.scalafmt.conf` file and switching the execution goal from `format` to `apply`.

----

- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#scalafmt